### PR TITLE
Add npm prepare to allow direct npm install from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "source ./scripts.sh; lint",
     "lint_compact": "source ./scripts.sh; lint_compact",
     "build": "rm -rf ./dist;tsc --declaration",
+    "prepare": "npm run build",
     "release": "yarn build; np"
   },
   "repository": {


### PR DESCRIPTION
Tested - was able to install into a local project with package.json line:
    "scriptable-utils": "github:chris-brightman/scriptable-utils#5f38830"
